### PR TITLE
fix empty localStorage on result page

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -67,7 +67,8 @@ const routes = [
     component: GuideFactice,
     beforeEnter (to) {
       const stepsStore = useStepsStore()
-      if (stepsStore.currentStep !== 0) {
+      const resultStore = useResultStore()
+      if (stepsStore.currentStep !== 0 && resultStore.confidence !== null) {
         return true
       }
       return { name: 'Start' }
@@ -117,7 +118,7 @@ const routes = [
     component: Result,
     beforeEnter (to) {
       const resultStore = useResultStore()
-      if (resultStore.img !== null || resultStore.confidence !== 0) {
+      if (resultStore.img !== null) {
         return true
       }
       return { name: 'Start' }

--- a/frontend/src/views/GuideFactice/GuideFactice.vue
+++ b/frontend/src/views/GuideFactice/GuideFactice.vue
@@ -28,8 +28,8 @@ const currentStep = computed({
 })
 
 const steps = []
-steps.length = results[resultStore.typology].stepsNumber
-steps.fill(' ')
+steps.length = results[resultStore.typology]?.stepsNumber
+steps?.fill(' ')
 
 guideSteps.value = results[resultStore.typology].stepsNumber === 4
   ? [...guideSteps]


### PR DESCRIPTION
Fix empty LocalStorage on result page. Redirect to start page
<img width="1157" alt="Capture d’écran 2023-02-16 à 13 41 16" src="https://user-images.githubusercontent.com/9094581/220612327-229ae947-1c82-4aed-b3bb-c7e71ad9ac94.png">
