### PR TITLE
fix: 🚑 fixes after users testing experience

### DIFF
--- a/frontend/src/components/HeaderMain.vue
+++ b/frontend/src/components/HeaderMain.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 
 const router = useRouter()
+const route = useRoute()
 
 const logoText = [
   'Ministère',
@@ -42,6 +43,7 @@ function onClickOnInfo (event) {
     @click="onClickOnLogo"
   >
     <span
+      v-if="route.name !== 'Home'"
       class="information fr-icon-info-line"
       aria-hidden="true"
       @click="onClickOnInfo"


### PR DESCRIPTION
Fixes #147 
- [x] Sur la page Résultats: message vote pouce non visible
- [x] Sur le carrousel première page : parfois le bouton commencer est sous les points du carrousel
- [x] Sur la 1e pages de tutos factices "Attention" : le bas de encadré rouge est masqué par les boutons du bas
- [x] Dans tutos factices quand possibilité zoom : pouvoir zoom pinch avec les 2 doigts
- [x] Sur la 2e page tutos factices, 1e étape/4 mettre en gras "doigt" pour "doigt hors du pontet"
- [x] Sur tous les textes de tutos avec le gif, vérifier qu'il y a du gras dans le texte (voir avec @leihuayi)
- [x] [Code] Enlever la variable selectedAmmo pour utiliser uniquement isFactice, et la renommer en "isDummy" (voir avec @leihuayi)
- [x] Modification de la visibilité du zoom sur les images