### PR TITLE
Single requirements file

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,10 +14,10 @@ RUN apt update && apt install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # install python libraries (except torch)
-COPY requirements/ requirements/
+COPY requirements.txt .
 ENV PIP_CERT=$CACERT_LOCATION
 RUN pip --default-timeout=300 install --upgrade pip \
-    && pip --default-timeout=300 install --no-cache-dir -r requirements/common.txt \
+    && pip --default-timeout=300 install --no-cache-dir -r requirements.txt \
     && rm -r /root/.cache
 
 ARG VERSION
@@ -31,14 +31,14 @@ RUN mkdir -p src/weights \
 
 # launch website
 FROM base as dev
-RUN pip --default-timeout=300 install --no-cache-dir -r requirements/dev.txt
 CMD ["uvicorn", "src.main:app", "--reload", "--host", "0.0.0.0", "--port", "5000"]
 
 FROM base as test
-RUN pip install -r requirements/dev.txt && pip install requests && rm -r /root/.cache
+RUN pip install requests && rm -r /root/.cache
 COPY tests/ tests/
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "5000"]
 
 FROM base as prod
-RUN pip install --no-cache-dir -r requirements/prod.txt
+RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu \
+    torch==1.13.0+cpu torchvision==0.14.0+cpu && rm -r /root/.cache
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
 fastapi==0.68.0
 uvicorn==0.14.0
 python-multipart>=0.0.5
@@ -7,3 +8,5 @@ user-agents==2.2.0
 ua-parser==0.10.0
 python-openstackclient==5.8.0
 python-swiftclient==4.0.0
+torch==1.13.0
+torchvision==0.14.0

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -1,3 +1,0 @@
---extra-index-url https://download.pytorch.org/whl/cpu
-torch==1.13.0
-torchvision==0.14.0

--- a/backend/requirements/prod.txt
+++ b/backend/requirements/prod.txt
@@ -1,3 +1,0 @@
---extra-index-url https://download.pytorch.org/whl/cpu
-torch==1.13.0+cpu
-torchvision==0.14.0+cpu


### PR DESCRIPTION
In previous versions, having 3 requirements files forced us to install torch package after copy of src/ which caused the rebuild of backend image very frequently and forced the devs to wait a long time every time.
- Use single requirements file which is installed before copy of src
- Overwrite torch and torchvision versions for prod install